### PR TITLE
Remove incompatible default syntax

### DIFF
--- a/lib/Gracenote.js
+++ b/lib/Gracenote.js
@@ -234,7 +234,7 @@ function Gracenote(clientId, clientTag, userId, requestDefaults) {
 		return "";
 	}
 	
-	this._getOETElem = function(root||{}) {
+	this._getOETElem = function(root) {
 		if (root) {
 			var out = [];
 			for (var i = 0; i < root.length; i++) {


### PR DESCRIPTION
BTW: I reviewed the related private method. I guess the `root` shouldn't be default to `{}` since you use `root.length` later.

Thanks.
